### PR TITLE
feat(error): Display more obviously the underlying error

### DIFF
--- a/src/FlakyDetector.js
+++ b/src/FlakyDetector.js
@@ -32,9 +32,8 @@ class FlakyDetector {
     const { command, directory } = this.options
     const referenceTestLoader = loadingText(`Executing reference test ${command}...`)
     const res = await execShellCommand(command).catch(error => {
-      this.log(error)
       referenceTestLoader.fail()
-      referenceTestLoader.text = `Your test fails : ${error}\n`
+      console.log(error.toString().red);
       process.exit(1)
     })
     this.log(res)


### PR DESCRIPTION
I tried the flaky detector, but it refused to run, with exit code 1.
![image](https://user-images.githubusercontent.com/283419/113278361-2242cf00-92e2-11eb-87c6-f3b36db7eefc.png)

Didn't give me much information, so I monkey patched the code, to see what was going on and discovered that my rails command itself was failing (because I forgot to do a bundle install), but the module was swallowing the error, making it hard to understand how to fix the issue.

![image](https://user-images.githubusercontent.com/283419/113278303-0fc89580-92e2-11eb-8e00-9c820c65c035.png)

With this PR, the underlying error is now much more visible, allowing to quickly diagnose what went wrong (it's not because it's flaky, it's because the command itself failed)

![image](https://user-images.githubusercontent.com/283419/113279352-44891c80-92e3-11eb-92a2-0f65b355e2c9.png)
