### PR TITLE
Fix missing this

### DIFF
--- a/src/FlakyDetector.js
+++ b/src/FlakyDetector.js
@@ -101,7 +101,7 @@ class FlakyDetector {
     } catch (error) {
       this.log(error)
       // Error for all screenshots of the round i
-      Object.keys(this.screenshots).map(key => screenshots[key].error++)
+      Object.keys(this.screenshots).map(key => this.screenshots[key].error++)
     }
   }
 


### PR DESCRIPTION
Without it flaky detector is stuck with the unhandled promise rejection error if test fails due to an error